### PR TITLE
Add function to parse configuration from a bucket URL

### DIFF
--- a/lib/fss/s3.ex
+++ b/lib/fss/s3.ex
@@ -10,6 +10,7 @@ defmodule FSS.S3 do
 
     defstruct [
       :access_key_id,
+      :bucket,
       :region,
       :secret_access_key,
       :endpoint,
@@ -22,6 +23,7 @@ defmodule FSS.S3 do
     The attributes are:
 
     * `:access_key_id` - This attribute is required.
+    * `:bucket` - A valid bucket name. This attribute is required.
     * `:region` - This attribute is required.
     * `:secret_access_key` - This attribute is required.
     * `:endpoint` - This attribute is optional. If specified, then `:region` is ignored.
@@ -31,6 +33,7 @@ defmodule FSS.S3 do
     """
     @type t :: %__MODULE__{
             access_key_id: String.t(),
+            bucket: String.t(),
             region: String.t(),
             secret_access_key: String.t(),
             endpoint: String.t() | nil,
@@ -43,19 +46,17 @@ defmodule FSS.S3 do
     Represents the S3 resource itself.
     """
 
-    defstruct [:bucket, :key, :config]
+    defstruct [:key, :config]
 
     @typedoc """
     The entry struct for S3.
 
     The attributes are:
 
-    * `:bucket` - A valid bucket name. This attribute is required.
     * `:key` - A valid key for the resource. This attribute is required.
     * `:config` - A valid S3 config from the type `Config.t()`. This attribute is required.
     """
     @type t :: %__MODULE__{
-            bucket: String.t(),
             key: String.t(),
             config: Config.t()
           }
@@ -77,6 +78,9 @@ defmodule FSS.S3 do
       - `AWS_SECRET_ACCESS_KEY`
       - `AWS_REGION` or `AWS_DEFAULT_REGION`
       - `AWS_SESSION_TOKEN`
+
+      Although you can pass the `:bucket` as a configuration option, it's not
+      possible to override the bucket name from the URL.
   """
   @spec parse(String.t(), Keyword.t()) :: {:ok, Entry.t()} | {:error, Exception.t()}
   def parse(url, opts \\ []) do
@@ -89,23 +93,10 @@ defmodule FSS.S3 do
         config =
           opts
           |> Keyword.fetch!(:config)
-          |> case do
-            nil ->
-              config_from_system_env()
-
-            %Config{} = config ->
-              config
-
-            config when is_list(config) or is_map(config) ->
-              struct!(config_from_system_env(), config)
-
-            other ->
-              raise ArgumentError,
-                    "expect configuration to be a %FSS.S3.Config{} struct, a keyword list or a map. Instead got #{inspect(other)}"
-          end
+          |> normalize_config!()
           |> validate_config!()
 
-        {:ok, %Entry{bucket: bucket, key: key, config: config}}
+        {:ok, %Entry{key: key, config: %{config | bucket: bucket}}}
 
       _ ->
         {:error,
@@ -122,6 +113,18 @@ defmodule FSS.S3 do
     check!(config, :region, "AWS_REGION")
 
     config
+  end
+
+  defp normalize_config!(nil), do: config_from_system_env()
+  defp normalize_config!(%Config{} = config), do: config
+
+  defp normalize_config!(config) when is_list(config) or is_map(config) do
+    struct!(config_from_system_env(), config)
+  end
+
+  defp normalize_config!(other) do
+    raise ArgumentError,
+          "expect configuration to be a %FSS.S3.Config{} struct, a keyword list or a map. Instead got #{inspect(other)}"
   end
 
   defp check!(config, key, env) do

--- a/test/fss/s3_test.exs
+++ b/test/fss/s3_test.exs
@@ -17,10 +17,11 @@ defmodule FSS.S3Test do
     end
 
     test "parses a s3:// style uri", %{config: config} do
-      assert {:ok, %Entry{bucket: "my-bucket", key: "my-file.png", config: %Config{} = config}} =
+      assert {:ok, %Entry{key: "my-file.png", config: %Config{} = config}} =
                S3.parse("s3://my-bucket/my-file.png", config: config)
 
       assert is_nil(config.endpoint)
+      assert config.bucket == "my-bucket"
       assert config.secret_access_key == "my-secret"
       assert config.access_key_id == "my-access"
       assert config.region == "us-west-2"
@@ -38,6 +39,7 @@ defmodule FSS.S3Test do
                )
 
       assert config.endpoint == "localhost"
+      assert config.bucket == "my-bucket"
       assert config.secret_access_key == "my-secret-1"
       assert config.access_key_id == "my-access-key-1"
       assert config.region == "eu-east-1"
@@ -50,11 +52,14 @@ defmodule FSS.S3Test do
                    endpoint: "localhost",
                    secret_access_key: "my-secret-1",
                    access_key_id: "my-access-key-1",
+                   # We always ignore bucket from config.
+                   bucket: "random-name",
                    region: "eu-east-1"
                  }
                )
 
       assert config.endpoint == "localhost"
+      assert config.bucket == "my-bucket"
       assert config.secret_access_key == "my-secret-1"
       assert config.access_key_id == "my-access-key-1"
       assert config.region == "eu-east-1"

--- a/test/fss/s3_test.exs
+++ b/test/fss/s3_test.exs
@@ -115,4 +115,89 @@ defmodule FSS.S3Test do
                    end
     end
   end
+
+  describe "parse_config_from_bucket_url/2" do
+    setup do
+      default_config = [
+        secret_access_key: "my-secret",
+        access_key_id: "my-access"
+      ]
+
+      [default_config: default_config]
+    end
+
+    test "parses a path-style AWS S3 url", %{default_config: default_config} do
+      assert {:ok, config} =
+               S3.parse_config_from_bucket_url("https://s3.us-west-2.amazonaws.com/my-bucket",
+                 config: default_config
+               )
+
+      assert %Config{} = config
+      assert config.region == "us-west-2"
+      assert config.bucket == "my-bucket"
+      assert is_nil(config.endpoint)
+    end
+
+    test "parses a host-style AWS S3 url", %{default_config: default_config} do
+      assert {:ok, config} =
+               S3.parse_config_from_bucket_url("https://my-bucket-1.s3.us-west-2.amazonaws.com/",
+                 config: default_config
+               )
+
+      assert %Config{} = config
+      assert config.region == "us-west-2"
+      assert config.bucket == "my-bucket-1"
+      assert is_nil(config.endpoint)
+    end
+
+    test "parses a path-style S3 compatible url", %{default_config: default_config} do
+      assert {:ok, config} =
+               S3.parse_config_from_bucket_url("https://storage.googleapis.com/my-bucket-on-gcp",
+                 config: default_config
+               )
+
+      assert %Config{} = config
+      assert is_nil(config.region)
+      assert config.bucket == "my-bucket-on-gcp"
+      assert config.endpoint == "https://storage.googleapis.com"
+    end
+
+    test "parses a path-style S3 compatible url with a port", %{default_config: default_config} do
+      assert {:ok, config} =
+               S3.parse_config_from_bucket_url("http://localhost:4852/my-bucket-on-lh",
+                 config: default_config
+               )
+
+      assert %Config{} = config
+      assert is_nil(config.region)
+      assert config.bucket == "my-bucket-on-lh"
+      assert config.endpoint == "http://localhost:4852"
+    end
+
+    test "cannot extract bucket from host-style S3 url", %{default_config: default_config} do
+      assert {:error, error} =
+               S3.parse_config_from_bucket_url("https://my-bucket-on-gcp.storage.googleapis.com",
+                 config: default_config
+               )
+
+      message =
+        "cannot extract bucket name from URL. Expected URL in the format " <>
+          "https://s3.[region].amazonaws.com/[bucket], got: " <>
+          "https://my-bucket-on-gcp.storage.googleapis.com"
+
+      assert error == ArgumentError.exception(message)
+    end
+
+    test "cannot parse url without host", %{default_config: default_config} do
+      assert {:error, error} =
+               S3.parse_config_from_bucket_url("/my-path",
+                 config: default_config
+               )
+
+      message =
+        "expected URL in the format https://s3.[region].amazonaws.com/[bucket], got: /my-path"
+
+      assert error == ArgumentError.exception(message)
+    end
+  end
 end


### PR DESCRIPTION
This is also changing the `:bucket` field from the `FSS.S3.Entry` to `FSS.S3.Config` struct.