### PR TITLE
Hide secret values on S3 Config inspect

### DIFF
--- a/lib/fss/s3.ex
+++ b/lib/fss/s3.ex
@@ -8,6 +8,7 @@ defmodule FSS.S3 do
     Represents the configuration needed for accessing an S3 resource.
     """
 
+    @derive {Inspect, only: [:bucket, :region, :endpoint]}
     defstruct [
       :access_key_id,
       :bucket,

--- a/test/fss/s3_test.exs
+++ b/test/fss/s3_test.exs
@@ -156,4 +156,26 @@ defmodule FSS.S3Test do
                    end
     end
   end
+
+  describe "inspect(%Config{})" do
+    test "does not output secret values" do
+      config = %Config{
+        secret_access_key: "my-secret",
+        access_key_id: "my-access",
+        bucket: "my-bucket",
+        region: "my-region",
+        endpoint: "my-endpoint",
+        token: "my-token"
+      }
+
+      output = inspect(config)
+
+      assert output =~ "my-bucket"
+      assert output =~ "my-region"
+      assert output =~ "my-endpoint"
+      refute output =~ "my-access"
+      refute output =~ "my-secret"
+      refute output =~ "my-token"
+    end
+  end
 end


### PR DESCRIPTION
Hi there 😊

This PR hides some values containing potential secrets when inspecting S3.Config struct, what do you think?

Obrigado, cheers!